### PR TITLE
Add TCP sockets to the app

### DIFF
--- a/src/qt/decentralchat-qt/DecentralChat.pro
+++ b/src/qt/decentralchat-qt/DecentralChat.pro
@@ -1,4 +1,4 @@
-QT += core gui
+QT += core gui network
 QT_MAJOR_VERSION = 6
 RESOURCES = ../resources.qrc
 
@@ -10,9 +10,9 @@ CONFIG += c++20
 # In order to do so, uncomment the following line.
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
-SOURCES += $$files(*.c, true) + $$files(*.cpp, true)
+SOURCES += $$files(*.c, true) $$files(*.cpp, true)
 
-HEADERS = $$files(*.h, true) + $$files(*.hpp, true)
+HEADERS = $$files(*.h, true) $$files(*.hpp, true)
 
 FORMS += \
     ../ui/decentralchat.ui

--- a/src/qt/decentralchat-qt/client.cpp
+++ b/src/qt/decentralchat-qt/client.cpp
@@ -37,7 +37,6 @@ Client::~Client() {
 void Client::ConnectToHost(const QHostAddress& address, uint16_t port) {
 	connect(m_TcpSocket, &QAbstractSocket::connected, this, [this]() mutable {
 		std::cout << "Connected\n";
-		SendMessage("Hello, World!\n");
 	});
 
 

--- a/src/qt/decentralchat-qt/client.cpp
+++ b/src/qt/decentralchat-qt/client.cpp
@@ -28,12 +28,12 @@ Client::Client(QObject* parent):
 	m_ReceivedMessage.setDevice(m_TcpSocket);
     m_ReceivedMessage.setVersion(QDataStream::Qt_6_0);
 
-	connect(socket, &QTcpSocket::readyRead, this, [this]() {
+	connect(m_TcpSocket, &QTcpSocket::readyRead, this, [this]() {
         QByteArray data = m_TcpSocket->readAll();
         QString message = QString::fromUtf8(data);
         std::cout << "Received: " << message.toStdString() << "\n";
     });
-    connect(m_TcpSocket, &QAbstractSocket::errorOccurred, this, [=] {
+    connect(m_TcpSocket, &QAbstractSocket::errorOccurred, this, [this] {
 		std::cout << "Error: " << m_TcpSocket->errorString().toStdString() << "\n";
 	});
 }

--- a/src/qt/decentralchat-qt/client.cpp
+++ b/src/qt/decentralchat-qt/client.cpp
@@ -1,0 +1,55 @@
+//
+// This file is part of DecentralChat
+// Copyright (C) 2023 Ryan Smith, Jake Goodyear
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or any
+// later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <https://www.gnu.org/licenses/>
+//
+// Filename: client.hpp
+// Description: A TCP client connection
+//
+
+#include "client.hpp"
+
+Client::Client():
+	m_TcpSocket(new QTcpSocket(this))
+{
+	m_ReceivedMessage.setDevice(m_TcpSocket);
+    m_ReceivedMessage.setVersion(QDataStream::Qt_6_5);
+
+	connect(m_TcpSocket, &QIODevice::readyRead, this, &Client::FetchMessage);
+    connect(m_TcpSocket, &QAbstractSocket::errorOccurred, this, [=] {
+		std::cout << "Error: " << m_TcpSocket->errorString().toStdString() << std::endl;
+	});
+}
+
+Client::~Client() {
+	delete m_TcpSocket;
+}
+
+void Client::ConnectToHost(const QHostAddress& address, uint16_t port) {
+	m_TcpSocket->abort();
+	m_TcpSocket->connectToHost(address, port);
+}
+
+void Client::FetchMessage() {
+	m_ReceivedMessage.startTransaction();
+	QString message;
+	m_ReceivedMessage >> message; // Get the message from the data stream
+
+	if (!m_ReceivedMessage.commitTransaction()) {
+		return;
+	}
+
+	std::cout << "Message: " << message.toStdString() << std::endl;
+}

--- a/src/qt/decentralchat-qt/client.hpp
+++ b/src/qt/decentralchat-qt/client.hpp
@@ -1,0 +1,48 @@
+//
+// This file is part of DecentralChat
+// Copyright (C) 2023 Ryan Smith, Jake Goodyear
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or any
+// later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <https://www.gnu.org/licenses/>
+//
+// Filename: client.hpp
+// Description: A TCP client connection
+//
+
+#pragma once
+
+#include <iostream>
+
+#include <QAbstractSocket>
+#include <QDataStream>
+#include <QIODevice>
+#include <QString>
+#include <QObject>
+#include <QTcpSocket>
+
+class Client: public QObject {
+	Q_OBJECT
+
+public:
+	Client();
+	~Client();
+
+	void ConnectToHost(const QHostAddress& address, uint16_t port);
+
+private slots:
+	void FetchMessage();
+
+private:
+	QTcpSocket* m_TcpSocket;
+    QDataStream m_ReceivedMessage;
+};

--- a/src/qt/decentralchat-qt/client.hpp
+++ b/src/qt/decentralchat-qt/client.hpp
@@ -22,6 +22,8 @@
 #pragma once
 
 #include <iostream>
+#include <mutex>
+#include <condition_variable>
 
 #include <QAbstractSocket>
 #include <QDataStream>
@@ -45,4 +47,7 @@ private slots:
 private:
 	QTcpSocket* m_TcpSocket;
     QDataStream m_ReceivedMessage;
+
+	std::mutex m_Mutex;
+	std::condition_variable m_Cv;
 };

--- a/src/qt/decentralchat-qt/client.hpp
+++ b/src/qt/decentralchat-qt/client.hpp
@@ -21,9 +21,9 @@
 
 #pragma once
 
+#include <cstring>
 #include <iostream>
-#include <mutex>
-#include <condition_variable>
+#include <string>
 
 #include <QAbstractSocket>
 #include <QDataStream>
@@ -40,12 +40,8 @@ public:
 	~Client();
 
 	void ConnectToHost(const QHostAddress& address, uint16_t port);
-	void SendMessage(const QString& message);
+	void SendMessage(const std::string& message);
 
 private:
 	QTcpSocket* m_TcpSocket;
-    QDataStream m_ReceivedMessage;
-
-	std::mutex m_Mutex;
-	std::condition_variable m_Cv;
 };

--- a/src/qt/decentralchat-qt/client.hpp
+++ b/src/qt/decentralchat-qt/client.hpp
@@ -36,13 +36,11 @@ class Client: public QObject {
 	Q_OBJECT
 
 public:
-	Client();
+	explicit Client(QObject* parent = nullptr);
 	~Client();
 
 	void ConnectToHost(const QHostAddress& address, uint16_t port);
-
-private slots:
-	void FetchMessage();
+	void SendMessage(const QString& message);
 
 private:
 	QTcpSocket* m_TcpSocket;

--- a/src/qt/decentralchat-qt/mainwindow.cpp
+++ b/src/qt/decentralchat-qt/mainwindow.cpp
@@ -3,14 +3,13 @@
 
 MainWindow::MainWindow(QWidget* parent):
 	QMainWindow(parent),
-	ui(new Ui::MainWindow)
+	ui(new Ui::MainWindow),
+	m_Server(new Server)
 {
 	ui->setupUi(this);
 
-	Server server;
-
 	Client client;
-	client.ConnectToHost(server.GetHostname(), server.GetPort());
+	client.ConnectToHost(m_Server->GetHostname(), m_Server->GetPort());
 }
 
 MainWindow::~MainWindow() {

--- a/src/qt/decentralchat-qt/mainwindow.cpp
+++ b/src/qt/decentralchat-qt/mainwindow.cpp
@@ -5,7 +5,12 @@ MainWindow::MainWindow(QWidget* parent):
 	QMainWindow(parent),
 	ui(new Ui::MainWindow)
 {
-    ui->setupUi(this);
+	ui->setupUi(this);
+
+	Server server;
+
+	Client client;
+	client.ConnectToHost(server.GetHostname(), server.GetPort());
 }
 
 MainWindow::~MainWindow() {

--- a/src/qt/decentralchat-qt/mainwindow.cpp
+++ b/src/qt/decentralchat-qt/mainwindow.cpp
@@ -4,12 +4,10 @@
 MainWindow::MainWindow(QWidget* parent):
 	QMainWindow(parent),
 	ui(new Ui::MainWindow),
-	m_Server(new Server)
+	m_Server(new Server),
+	m_Client(new Client)
 {
 	ui->setupUi(this);
-
-	Client client;
-	client.ConnectToHost(m_Server->GetHostname(), m_Server->GetPort());
 }
 
 MainWindow::~MainWindow() {

--- a/src/qt/decentralchat-qt/mainwindow.hpp
+++ b/src/qt/decentralchat-qt/mainwindow.hpp
@@ -1,6 +1,27 @@
+//
+// This file is part of DecentralChat
+// Copyright (C) 2023 Ryan Smith, Jake Goodyear
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or any
+// later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <https://www.gnu.org/licenses/>
+//
+
 #pragma once
 
 #include <QMainWindow>
+
+#include "server.hpp"
+#include "client.hpp"
 
 QT_BEGIN_NAMESPACE
 namespace Ui {

--- a/src/qt/decentralchat-qt/mainwindow.hpp
+++ b/src/qt/decentralchat-qt/mainwindow.hpp
@@ -38,4 +38,5 @@ public:
 
 private:
 	Ui::MainWindow *ui;
+	Server* m_Server;
 };

--- a/src/qt/decentralchat-qt/mainwindow.hpp
+++ b/src/qt/decentralchat-qt/mainwindow.hpp
@@ -39,4 +39,5 @@ public:
 private:
 	Ui::MainWindow *ui;
 	Server* m_Server;
+	Client* m_Client;
 };

--- a/src/qt/decentralchat-qt/server.cpp
+++ b/src/qt/decentralchat-qt/server.cpp
@@ -43,10 +43,8 @@ Server::Server(QObject* parent):
 
 	std::cout << "The server is running on IP: " << m_HostAddress.toString().toStdString() << " Port: " << m_Port << "\n";
 
-	QString message = "Hello, World!";
-	connect(this, &QTcpServer::newConnection, this, [=, &message] {
+	connect(this, &QTcpServer::newConnection, this, [] {
 		std::cout << "Connection made" << "\n";
-		this->SendMessage(message);
 	});
 	connect(this, &QTcpServer::pendingConnectionAvailable, this, [] {
 		std::cout << "New connection available" << "\n";

--- a/src/qt/decentralchat-qt/server.cpp
+++ b/src/qt/decentralchat-qt/server.cpp
@@ -1,0 +1,76 @@
+//
+// This file is part of DecentralChat
+// Copyright (C) 2023 Ryan Smith, Jake Goodyear
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or any
+// later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <https://www.gnu.org/licenses/>
+//
+// Filename: server.cpp
+// Description: A TCP server
+//
+
+#include "server.hpp"
+
+Server::Server():
+	m_TcpServer(new QTcpServer(this))
+{
+    const QList<QHostAddress> ipAddressesList = QNetworkInterface::allAddresses();
+
+    // Use the first non-localhost IPv4 address
+    for (const QHostAddress& entry: ipAddressesList) {
+        if (entry != QHostAddress::LocalHost && entry.toIPv4Address()) {
+            m_HostAddress = entry;
+            break;
+        }
+    }
+
+    // If we did not find one, use IPv4 localhost
+    if (m_HostAddress.isNull()) {
+        m_HostAddress = QHostAddress(QHostAddress::LocalHost);
+	}
+
+	m_Port = 16000;//m_TcpServer->serverPort();
+
+	std::cout << "The server is running on IP: " << m_HostAddress.toString().toStdString() << " Port: " << m_Port << std::endl;
+
+	QString message = "Hello, World!";
+	connect(m_TcpServer, &QTcpServer::newConnection, this, [=, &message] {
+		this->SendMessage(message);
+	});
+
+	if (!m_TcpServer->listen(m_HostAddress, m_Port)) {
+		std::cout << "Unable to start the server. Error: " << m_TcpServer->errorString().toStdString() << std::endl;
+	}
+	else {
+		std::cout << "Listening..." << std::endl;
+	}
+}
+
+Server::~Server() {
+	delete m_TcpServer;
+}
+
+void Server::SendMessage(const QString& message) {
+	std::cout << "Sending message..." << std::endl;
+
+	QByteArray block;
+    QDataStream dataStream(&block, QIODevice::WriteOnly);
+    dataStream.setVersion(QDataStream::Qt_6_5);
+	dataStream << message; // Load the message into the data stream
+
+	QTcpSocket* clientConnection = m_TcpServer->nextPendingConnection();
+    connect(clientConnection, &QAbstractSocket::disconnected, clientConnection, &QObject::deleteLater);
+
+	clientConnection->write(block);
+    clientConnection->disconnectFromHost();
+}

--- a/src/qt/decentralchat-qt/server.cpp
+++ b/src/qt/decentralchat-qt/server.cpp
@@ -55,7 +55,7 @@ Server::Server(QObject* parent):
 				int index = m_IncomingData.indexOf('\n');
 				QString message = m_IncomingData.left(index);
 				m_IncomingData = m_IncomingData.mid(index + 1);
-				std::cout << "Received message: " << message << "\n";
+				std::cout << "Received message: " << message.toStdString() << "\n";
 			}
 
 			if (!m_IncomingData.isEmpty()) {

--- a/src/qt/decentralchat-qt/server.hpp
+++ b/src/qt/decentralchat-qt/server.hpp
@@ -1,0 +1,63 @@
+//
+// This file is part of DecentralChat
+// Copyright (C) 2023 Ryan Smith, Jake Goodyear
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or any
+// later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <https://www.gnu.org/licenses/>
+//
+// Filename: server.hpp
+// Description: A TCP server
+//
+
+#pragma once
+
+#include <iostream>
+
+#include <QAbstractSocket>
+#include <QByteArray>
+#include <QDataStream>
+#include <QHostAddress>
+#include <QIODevice>
+#include <QList>
+#include <QNetworkInterface>
+#include <QString>
+#include <QObject>
+#include <QTcpServer>
+#include <QTcpSocket>
+
+class Server: public QObject {
+	Q_OBJECT
+
+public:
+	Server();
+	~Server();
+
+	inline const QHostAddress& GetHostname() const;
+	inline uint16_t GetPort() const;
+
+public:
+	void SendMessage(const QString& message);
+
+private:
+	QTcpServer* m_TcpServer;
+	QHostAddress m_HostAddress;
+	uint16_t m_Port;
+};
+
+inline const QHostAddress& Server::GetHostname() const {
+	return m_HostAddress;
+}
+
+inline uint16_t Server::GetPort() const {
+	return m_Port;
+}

--- a/src/qt/decentralchat-qt/server.hpp
+++ b/src/qt/decentralchat-qt/server.hpp
@@ -22,6 +22,8 @@
 #pragma once
 
 #include <iostream>
+#include <thread>
+#include <chrono>
 
 #include <QAbstractSocket>
 #include <QByteArray>
@@ -35,23 +37,26 @@
 #include <QTcpServer>
 #include <QTcpSocket>
 
-class Server: public QObject {
+class Server: public QTcpServer {
 	Q_OBJECT
 
 public:
-	Server();
+	explicit Server(QObject* parent = nullptr);
 	~Server();
 
 	inline const QHostAddress& GetHostname() const;
 	inline uint16_t GetPort() const;
 
-public:
-	void SendMessage(const QString& message);
+protected:
+	void incomingConnection(qintptr socketDescriptor) override;
 
 private:
 	QTcpServer* m_TcpServer;
 	QHostAddress m_HostAddress;
 	uint16_t m_Port;
+
+signals:
+	void MessageReceived(const QString& message);
 };
 
 inline const QHostAddress& Server::GetHostname() const {

--- a/src/qt/decentralchat-qt/server.hpp
+++ b/src/qt/decentralchat-qt/server.hpp
@@ -22,8 +22,6 @@
 #pragma once
 
 #include <iostream>
-#include <thread>
-#include <chrono>
 
 #include <QAbstractSocket>
 #include <QByteArray>
@@ -36,6 +34,7 @@
 #include <QObject>
 #include <QTcpServer>
 #include <QTcpSocket>
+#include <QTimer>
 
 class Server: public QTcpServer {
 	Q_OBJECT
@@ -47,13 +46,13 @@ public:
 	inline const QHostAddress& GetHostname() const;
 	inline uint16_t GetPort() const;
 
-protected:
-	void incomingConnection(qintptr socketDescriptor) override;
-
 private:
 	QTcpServer* m_TcpServer;
+	QTcpSocket* m_CurrentSocket = new QTcpSocket();
+
 	QHostAddress m_HostAddress;
 	uint16_t m_Port;
+	QString m_IncomingData;
 
 signals:
 	void MessageReceived(const QString& message);

--- a/src/qt/ui/decentralchat.ui
+++ b/src/qt/ui/decentralchat.ui
@@ -6,40 +6,34 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>800</width>
-    <height>600</height>
+    <width>922</width>
+    <height>705</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>MainWindow</string>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <widget class="QLabel" name="label">
-    <property name="geometry">
-     <rect>
-      <x>210</x>
-      <y>170</y>
-      <width>391</width>
-      <height>131</height>
-     </rect>
-    </property>
-    <property name="sizePolicy">
-     <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-      <horstretch>0</horstretch>
-      <verstretch>0</verstretch>
-     </sizepolicy>
-    </property>
-    <property name="text">
-     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:64pt;&quot;&gt;Hello, World!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-    </property>
-   </widget>
+   <layout class="QHBoxLayout" name="horizontalLayout_2">
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:64pt;&quot;&gt;Hello, World!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+   </layout>
   </widget>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>800</width>
+     <width>922</width>
      <height>24</height>
     </rect>
    </property>


### PR DESCRIPTION
## Features

- `Server` class
    - Derived from `QTcpServer`
    - Accept incoming connections from a client
    - Read incoming messages from a socket connection
- `Client` class
    - Derived from `QObject` (could derive from `QTcpSocket` in the future? Not sure)
    - Connect to any active instance of the `Server` class using an IP (`QHostAddress`, might accept a `QString` in the future instead) and port (`uint16_t`)
    - Send messages (strings only for now)
    - Works asynchronously (no thread blocking) so the app should still run in the background is a message is sent or connection is made

## Usage

### Server

#### Instantiation

```cpp
Server server; // Server with no parent object (i.e., nullptr)
// OR
Server server(parentClassPtr); // Server with parent object
```

#### Listening

Currently, the server begins listening in the background as soon as the class is instantiated. This could change in the future.

#### IP and Port

The server currently detects a local IP address to host itself from, and a port has to be picked arbitrarily. In my testing, I used port 1600. This will change on the final implementation.

### Client

#### Instantiation

```cpp
Client client; // Client with no parent object (i.e., nullptr)
// OR
Client client(parentObj); // Client with parent object
```

#### Connecting to the Server

```cpp
client.ConnectToHost(QHostAddress("192.168.1.1", 8080);
```

#### Sending a message (writing to the socket)

```cpp
client.SendMessage("Hello, World!");
```

### Notes

1. Both `Server` and `Client` have `explicit` constructors, so neither class can be used for copy-initialization. I made this decision because the following code looks weird:

    ```cpp
    // Copy-initialization for the parent object argument
    Server server = parentObj;
    Client client = parentObj;
    ```
    Even if we aren't planning to ever use that, why not have the compiler enforce it 🤷🏻‍♂️ 

2. Originally, the `SendMessage` function accepted a `QString` as an argument. `Qstring`s are UTF-16 encoded, and there seemed to occasionally be a problem when reading back the data where it wouldn't be decoded properly. Converting the `QString` to UTF-8 didn't seem to fix this issue, so I switched to taking in a `std::string` (which is UTF-8 encoded). The data written to the socket itself is a `const char*`. 